### PR TITLE
feat: surface entity labels from blackboard and fix repeated-ID bugs (#21)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export class ReflexDevtools {
   private _blackboardPanel: BlackboardPanel | null = null;
   private _eventsPanel: EventsPanel | null = null;
   private _userFocusedWorkflowId: string | null = null;
+  private _userFocusedDepth: number | null = null;
 
   constructor(engine: ReflexEngine, options: DevtoolsOptions = {}) {
     this._engine = engine;
@@ -123,11 +124,13 @@ export class ReflexDevtools {
     });
 
     // Stack panel → DAG: click frame switches workflow view
-    this._stackPanel?.events.on('frame-click', ({ workflowId }) => {
+    this._stackPanel?.events.on('frame-click', ({ workflowId, depth }) => {
       if (!this._dagPanel) return;
-      // If clicking the engine's active workflow, clear user focus (resume auto-follow)
+      // If clicking the engine's active frame (highest depth), clear user focus (resume auto-follow)
       const snap = this._engine.snapshot();
-      this._userFocusedWorkflowId = workflowId === snap.currentWorkflowId ? null : workflowId;
+      const isActiveFrame = depth === (snap.stack?.length ?? 0);
+      this._userFocusedWorkflowId = isActiveFrame ? null : workflowId;
+      this._userFocusedDepth = isActiveFrame ? null : depth;
       this._dagPanel.switchToWorkflow(workflowId);
       this._dagPanel.expand();
     });
@@ -172,6 +175,7 @@ export class ReflexDevtools {
     on('blackboard:write', (payload) => {
       const { entries, workflow } = payload as { entries: BlackboardEntry[]; workflow: Workflow };
       this._blackboardPanel?.onBlackboardWrite(entries, workflow);
+      this._stackPanel?.onBlackboardWrite(entries, workflow);
       this._eventsPanel?.onBlackboardWrite(entries, workflow);
       // Re-evaluate edge viability — blackboard change may affect guard results
       this._updateEdgeViability();
@@ -187,10 +191,16 @@ export class ReflexDevtools {
 
     on('workflow:pop', (payload) => {
       const { frame, workflow } = payload as { frame: StackFrame; workflow: Workflow };
-      const preserveView = this._userFocusedWorkflowId === workflow.id;
-      // Only clear focus if the focused workflow itself was popped (not when returning to it)
-      if (this._userFocusedWorkflowId === frame.workflowId) {
-        this._userFocusedWorkflowId = null;
+      const preserveView = this._userFocusedWorkflowId != null;
+      // Clear focus if the focused depth was the popped entry (top of stack)
+      if (this._userFocusedDepth != null) {
+        const snap = this._engine.snapshot();
+        // The popped frame had depth = stack.length (now stack.length + 1 pre-pop)
+        const poppedDepth = (snap.stack?.length ?? 0) + 1;
+        if (this._userFocusedDepth >= poppedDepth) {
+          this._userFocusedWorkflowId = null;
+          this._userFocusedDepth = null;
+        }
       }
       this._dagPanel?.onWorkflowPop(frame, workflow, { preserveView });
       this._stackPanel?.onWorkflowPop(frame, workflow);
@@ -203,12 +213,10 @@ export class ReflexDevtools {
         payload as { discardedFrames: StackFrame[]; targetDepth: number;
                      restoredWorkflow: Workflow; restoredNode: Node; reinvoke: boolean };
 
-      // Clear user focus if the focused workflow was discarded
-      if (this._userFocusedWorkflowId) {
-        const discardedIds = new Set(discardedFrames.map((f: StackFrame) => f.workflowId));
-        if (discardedIds.has(this._userFocusedWorkflowId)) {
-          this._userFocusedWorkflowId = null;
-        }
+      // Clear user focus if the focused depth is above the restored depth
+      if (this._userFocusedDepth != null && this._userFocusedDepth > targetDepth) {
+        this._userFocusedWorkflowId = null;
+        this._userFocusedDepth = null;
       }
 
       this._stackPanel?.onStackUnwind(discardedFrames, restoredWorkflow, restoredNode);
@@ -235,6 +243,7 @@ export class ReflexDevtools {
 
     on('session:reset' as EngineEvent, () => {
       this._userFocusedWorkflowId = null;
+      this._userFocusedDepth = null;
       this._stackPanel?.resetSession();
       this._hydrateFromSnapshot();
     });

--- a/src/panels/stack/stack-panel.ts
+++ b/src/panels/stack/stack-panel.ts
@@ -1,4 +1,4 @@
-import type { Workflow, Node, StackFrame } from '@corpus-relica/reflex';
+import type { Workflow, Node, StackFrame, BlackboardEntry } from '@corpus-relica/reflex';
 import { Panel, type PanelOptions } from '../panel.js';
 import { className } from '../../core/class-name.js';
 import { el } from '../../core/dom.js';
@@ -8,9 +8,33 @@ export interface StackEntry {
   workflowId: string;
   currentNodeId: string;
   depth: number;
+  label?: string;
   status?: 'completed';
   order?: number;
   parentNodeId?: string;
+}
+
+const LABEL_KEYS = ['label', 'name', 'title', 'description'] as const;
+
+/** Extract a human-readable label from blackboard entries using a priority key heuristic. */
+function labelFromBlackboard(blackboard: BlackboardEntry[]): string | undefined {
+  // For each priority key, scan newest-to-oldest so latest write wins
+  for (const key of LABEL_KEYS) {
+    for (let i = blackboard.length - 1; i >= 0; i--) {
+      const entry = blackboard[i];
+      if (entry.key !== key) continue;
+      const v = entry.value;
+      if (typeof v === 'string' && v.length > 0) return v;
+      if (typeof v === 'number') return String(v);
+      // Check nested .name for object values
+      if (v != null && typeof v === 'object' && 'name' in (v as Record<string, unknown>)) {
+        const name = (v as Record<string, unknown>).name;
+        if (typeof name === 'string' && name.length > 0) return name;
+      }
+      break; // Found key but value not usable — try next priority key
+    }
+  }
+  return undefined;
 }
 
 export interface StackPanelEvents {
@@ -26,7 +50,7 @@ export class StackPanel extends Panel {
   private _entries: StackEntry[] = [];
   private _completedEntries: StackEntry[] = [];
   private _orderCounter = 0;
-  private _focusedWorkflowId: string | null = null;
+  private _focusedDepth: number | null = null;
 
   constructor(container: HTMLElement, options?: PanelOptions) {
     super(container, options);
@@ -39,27 +63,36 @@ export class StackPanel extends Panel {
 
   update(snapshot: unknown): void {
     // Hydrate from engine snapshot
-    const snap = snapshot as { stack?: StackFrame[]; currentWorkflowId?: string; currentNodeId?: string } | null;
+    const snap = snapshot as {
+      stack?: StackFrame[];
+      currentWorkflowId?: string;
+      currentNodeId?: string;
+      currentBlackboard?: BlackboardEntry[];
+    } | null;
     if (!snap) return;
     this._entries = [];
     this._completedEntries = [];
-    // Build stack from snapshot — current frame is not on the stack array
+    const stackLen = snap.stack?.length ?? 0;
+    // Active frame first (highest depth)
+    if (snap.currentWorkflowId) {
+      this._entries.push({
+        workflowId: snap.currentWorkflowId,
+        currentNodeId: snap.currentNodeId ?? '',
+        depth: stackLen,
+        label: snap.currentBlackboard ? labelFromBlackboard(snap.currentBlackboard) : undefined,
+      });
+    }
+    // Parent frames: stack[0] = most recent parent → stack[N-1] = oldest
     if (snap.stack) {
-      for (let i = snap.stack.length - 1; i >= 0; i--) {
+      for (let i = 0; i < stackLen; i++) {
         const frame = snap.stack[i];
         this._entries.push({
           workflowId: frame.workflowId,
           currentNodeId: frame.currentNodeId,
-          depth: i,
+          depth: stackLen - 1 - i,
+          label: frame.blackboard ? labelFromBlackboard(frame.blackboard) : undefined,
         });
       }
-    }
-    if (snap.currentWorkflowId) {
-      this._entries.unshift({
-        workflowId: snap.currentWorkflowId,
-        currentNodeId: snap.currentNodeId ?? '',
-        depth: (snap.stack?.length ?? 0),
-      });
     }
     this._render();
   }
@@ -71,8 +104,21 @@ export class StackPanel extends Panel {
     }
   }
 
+  onBlackboardWrite(entries: BlackboardEntry[], _workflow: Workflow): void {
+    if (this._entries.length === 0) return;
+    const newLabel = labelFromBlackboard(entries);
+    if (newLabel !== undefined) {
+      this._entries[0].label = newLabel;
+      this._render();
+    }
+  }
+
   onWorkflowPush(frame: StackFrame, childWorkflow: Workflow): void {
-    // The frame is the parent being suspended; the child is now current
+    // The frame is the parent being suspended; update its label from blackboard
+    if (this._entries.length > 0 && frame.blackboard) {
+      this._entries[0].label = labelFromBlackboard(frame.blackboard);
+    }
+    // The child is now current (highest depth)
     this._entries.unshift({
       workflowId: childWorkflow.id,
       currentNodeId: '',
@@ -82,10 +128,10 @@ export class StackPanel extends Panel {
     this._render();
   }
 
-  onWorkflowPop(frame: StackFrame, parentWorkflow: Workflow): void {
-    // If the focused workflow was popped, clear user focus
-    if (this._focusedWorkflowId === frame.workflowId) {
-      this._focusedWorkflowId = null;
+  onWorkflowPop(_frame: StackFrame, parentWorkflow: Workflow): void {
+    // If the focused entry was popped (always index 0 = highest depth), clear focus
+    if (this._focusedDepth != null && this._entries.length > 0 && this._entries[0].depth === this._focusedDepth) {
+      this._focusedDepth = null;
     }
     // Pop the current, move to completed
     if (this._entries.length > 0) {
@@ -111,25 +157,23 @@ export class StackPanel extends Panel {
   }
 
   onStackUnwind(discardedFrames: StackFrame[], restoredWorkflow: Workflow, restoredNode: Node): void {
-    const discardedIds = new Set(discardedFrames.map(f => f.workflowId));
+    // Discard the top N entries (discarded frames always correspond to the
+    // topmost stack entries). Using count rather than workflowId matching
+    // is critical when the stack contains repeated workflow IDs.
+    const discardCount = discardedFrames.length;
+    const discarded = this._entries.splice(0, discardCount);
 
-    // Clear user focus if the focused workflow was discarded
-    if (this._focusedWorkflowId && discardedIds.has(this._focusedWorkflowId)) {
-      this._focusedWorkflowId = null;
+    // Clear user focus if the focused entry was among those discarded
+    if (this._focusedDepth != null && discarded.some(e => e.depth === this._focusedDepth)) {
+      this._focusedDepth = null;
     }
 
-    // Partition entries: discarded move to completed, rest survive
-    const surviving: StackEntry[] = [];
-    for (const entry of this._entries) {
-      if (discardedIds.has(entry.workflowId)) {
-        entry.status = 'completed';
-        entry.order = ++this._orderCounter;
-        this._completedEntries.push(entry);
-      } else {
-        surviving.push(entry);
-      }
+    // Move discarded entries to completed
+    for (const entry of discarded) {
+      entry.status = 'completed';
+      entry.order = ++this._orderCounter;
+      this._completedEntries.push(entry);
     }
-    this._entries = surviving;
 
     // Update active entry to restored workflow/node
     if (this._entries.length > 0) {
@@ -148,12 +192,12 @@ export class StackPanel extends Panel {
     this._entries = [];
     this._completedEntries = [];
     this._orderCounter = 0;
-    this._focusedWorkflowId = null;
+    this._focusedDepth = null;
     this._render();
   }
 
-  private _renderEntry(entry: StackEntry, focusedId: string | undefined, completed: boolean): HTMLElement {
-    const isFocused = !completed && entry.workflowId === focusedId;
+  private _renderEntry(entry: StackEntry, focusedDepth: number | undefined, completed: boolean): HTMLElement {
+    const isFocused = !completed && entry.depth === focusedDepth;
     let cls = className('stack', 'frame');
     if (isFocused) cls += ` ${className('stack', 'frame', 'current')}`;
     if (completed) cls += ` ${className('stack', 'frame', 'completed')}`;
@@ -171,6 +215,14 @@ export class StackPanel extends Panel {
     const depthLabel = el('span', { class: className('stack', 'depth') });
     depthLabel.textContent = `[${entry.depth}]`;
 
+    // Optional entity label from blackboard
+    let labelEl: HTMLElement | undefined;
+    if (entry.label) {
+      labelEl = el('span', { class: className('stack', 'label') });
+      labelEl.textContent = entry.label;
+      labelEl.title = entry.label;
+    }
+
     if (completed && entry.order != null) {
       const orderLabel = el('span', { class: className('stack', 'order') });
       orderLabel.textContent = `#${entry.order}`;
@@ -181,13 +233,13 @@ export class StackPanel extends Panel {
       const parentLabel = el('span', { class: className('stack', 'parent') });
       parentLabel.textContent = `\u2190 ${entry.parentNodeId}`;
       parentLabel.title = entry.parentNodeId;
-      row.append(indicator, wfLabel, nodeLabel, parentLabel, depthLabel);
+      row.append(indicator, wfLabel, ...(labelEl ? [labelEl] : []), nodeLabel, parentLabel, depthLabel);
     } else {
-      row.append(indicator, wfLabel, nodeLabel, depthLabel);
+      row.append(indicator, wfLabel, ...(labelEl ? [labelEl] : []), nodeLabel, depthLabel);
     }
 
     row.addEventListener('click', () => {
-      this._focusedWorkflowId = entry.workflowId;
+      this._focusedDepth = entry.depth;
       this._render();
       this.events.emit('frame-click', { workflowId: entry.workflowId, depth: entry.depth });
     });
@@ -198,11 +250,11 @@ export class StackPanel extends Panel {
     if (!this._list) return;
     this._list.innerHTML = '';
 
-    // Focused workflow defaults to the engine's active (top of stack)
-    const focusedId = this._focusedWorkflowId ?? this._entries[0]?.workflowId;
+    // Focused depth defaults to the engine's active (top of stack)
+    const focusedDepth = this._focusedDepth ?? this._entries[0]?.depth;
 
     for (const entry of this._entries) {
-      this._list.appendChild(this._renderEntry(entry, focusedId, false));
+      this._list.appendChild(this._renderEntry(entry, focusedDepth, false));
     }
 
     // Completed entries separator + rows
@@ -212,7 +264,7 @@ export class StackPanel extends Panel {
       this._list.appendChild(sep);
 
       for (const entry of this._completedEntries) {
-        this._list.appendChild(this._renderEntry(entry, focusedId, true));
+        this._list.appendChild(this._renderEntry(entry, focusedDepth, true));
       }
     }
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -185,6 +185,16 @@
   white-space: nowrap;
   max-width: 100px;
 }
+.rx-stack_label {
+  color: var(--rx-text-muted);
+  flex-shrink: 0;
+  font-size: 9px;
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
 
 /* === Blackboard Panel === */
 .rx-bb_toolbar {


### PR DESCRIPTION
## Summary
When multiple workflows of the same type are on the stack (e.g. repeated
`physical-object` → `semantic-position` chains), all entries looked identical.
This PR extracts human-readable labels from each frame's blackboard and displays
them alongside the workflowId in the stack panel.

Also fixes two bugs with repeated workflow IDs discovered during development.

## Issue Resolution
Closes #21

## Key Changes
- **`labelFromBlackboard()` helper** — scans blackboard entries for priority keys
  (`label`, `name`, `title`, `description`) newest-to-oldest, with nested `.name`
  fallback for object values
- **Label extraction** at three points: snapshot hydration (`update()`), workflow
  push (`onWorkflowPush()`), and live blackboard writes (`onBlackboardWrite()`)
- **Label rendering** as italic muted annotation after workflowId in stack rows
- **Bug fix: `onStackUnwind`** — replaced workflowId-set matching with count-based
  splice, fixing incorrect discard of all same-ID entries
- **Bug fix: focus identity** — replaced `_focusedWorkflowId` with `_focusedDepth`
  so clicking one repeated-ID frame no longer highlights all of them
- **Hydration order fix** — forward iteration matches Reflex contract (`stack[0]` =
  most recent parent) with correct depth calculation

## Testing
- `npx tsc --noEmit` passes
- `npm run build` passes