### PR TITLE
feat: add npm and Verdaccio publish infrastructure (#24)

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,67 @@
+# Publishing @corpus-relica/reflex-devtools
+
+## Local Development (Verdaccio)
+
+Uses the shared Verdaccio instance from `systema-relica-sdk` so all `@corpus-relica/*` packages resolve from one local registry.
+
+### Prerequisites
+
+1. Verdaccio running on `http://localhost:4873` (start from SDK repo: `yarn local-registry`)
+2. Local user created: `npm adduser --registry http://localhost:4873`
+
+### Publish to Verdaccio
+
+```bash
+# Bump version
+./scripts/bump-version.sh 0.2.0
+
+# Build and publish to local registry
+npm run publish:local
+```
+
+### Consuming projects
+
+```bash
+# Point scope at Verdaccio (if not already)
+npm config set @corpus-relica:registry http://localhost:4873
+
+# Install
+npm install @corpus-relica/reflex-devtools@0.2.0
+```
+
+## Release to npm (Public)
+
+For CD-compatible deployments where Verdaccio isn't available.
+
+### Prerequisites
+
+1. npm account with publish access to `@corpus-relica` scope
+2. Logged in: `npm login`
+
+### Publish
+
+```bash
+# Bump version
+./scripts/bump-version.sh 0.2.0
+
+# Publish to npm (handles scope swap, build, browser auth, and restore)
+npm run publish:remote
+
+# Tag the release
+git add package.json package-lock.json
+git commit -m "v0.2.0"
+git tag -a v0.2.0 -m "v0.2.0"
+git push && git push --tags
+```
+
+The `publish:remote` script (`scripts/publish-npm.sh`) temporarily swaps `@corpus-relica` scope from Verdaccio to npmjs.org, publishes, then restores — even if publish fails.
+
+## Troubleshooting
+
+**"Cannot publish over existing version"** — Bump version first: `./scripts/bump-version.sh X.Y.Z`
+
+**"ECONNREFUSED localhost:4873"** — Start Verdaccio: `cd ../systema-relica-sdk && yarn local-registry`
+
+**"need auth"** — Create Verdaccio user: `npm adduser --registry http://localhost:4873`
+
+**"You must sign up for private packages"** — The `publishConfig.access: "public"` in package.json should handle this. If not, use `npm publish --access public`.

--- a/package.json
+++ b/package.json
@@ -33,13 +33,18 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "node scripts/build-css.mjs && tsup",
     "build:css": "node scripts/build-css.mjs",
     "build:watch": "tsup --watch",
     "dev": "vite demo",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "publish:local": "npm run clean && npm run build && npm publish --registry http://localhost:4873",
+    "publish:remote": "bash scripts/publish-npm.sh"
   },
   "peerDependencies": {
     "@corpus-relica/reflex": ">=1.0.0"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Usage: ./scripts/bump-version.sh <version>
+# Examples:
+#   ./scripts/bump-version.sh 0.2.0
+#   ./scripts/bump-version.sh 1.0.0
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: ./scripts/bump-version.sh <version>"
+  echo ""
+  echo "Examples:"
+  echo "  ./scripts/bump-version.sh 0.2.0"
+  echo "  ./scripts/bump-version.sh 1.0.0"
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Invalid version format. Expected X.Y.Z"
+  exit 1
+fi
+
+echo "Bumping to $VERSION..."
+
+sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+echo "  Updated package.json"
+
+npm install --silent --package-lock-only 2>/dev/null || true
+echo "  Updated lockfile"
+
+echo ""
+echo "Done. Next steps:"
+echo "  1. Build:   npm run build"
+echo "  2. Publish:"
+echo "     Local:   npm run publish:local"
+echo "     npm:     npm publish"

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Publish to public npm registry.
+# Temporarily swaps @corpus-relica scope from Verdaccio to npmjs.org,
+# runs npm publish (which opens browser for auth), then restores scope.
+
+ORIGINAL=$(npm config get @corpus-relica:registry 2>/dev/null || echo "")
+
+restore() {
+  if [ -n "$ORIGINAL" ]; then
+    npm config set @corpus-relica:registry "$ORIGINAL"
+    echo "Restored @corpus-relica:registry → $ORIGINAL"
+  fi
+}
+trap restore EXIT
+
+echo "Building..."
+npm run clean && npm run build
+
+echo ""
+echo "Switching @corpus-relica scope to npmjs.org..."
+npm config set @corpus-relica:registry https://registry.npmjs.org
+
+echo "Publishing (browser auth may open)..."
+npm publish --ignore-scripts
+
+echo ""
+echo "Published @corpus-relica/reflex-devtools@$(node -p "require('./package.json').version")"


### PR DESCRIPTION
## Summary
Adds publish infrastructure so `@corpus-relica/reflex-devtools` can be consumed via npm (for CD deployment) and Verdaccio (for local dev alongside SDK packages).

Closes #24

## Key Changes
- `publishConfig.access: "public"` for scoped npm publishing
- `publish:local` script for Verdaccio publishing
- `publish:remote` script with scope swap + trap-based restore for npm publishing
- `bump-version.sh` for guided semver bumping
- `PUBLISHING.md` documenting both workflows

## Implementation Notes
The `@corpus-relica` scope is typically pointed at Verdaccio locally (for SDK dev), so `npm publish` targets Verdaccio by default. The `publish:remote` script temporarily swaps the scope to npmjs.org and restores it via `trap` on exit.

v0.1.0 published to both Verdaccio and public npm during this work.

## Testing
- `npm pack --dry-run` verified correct package contents (18 files, 102kB)
- `publish:local` confirmed working against Verdaccio
- `publish:remote` confirmed working against npmjs.org (browser auth flow)